### PR TITLE
Ensure reference is using grunt.template.process

### DIFF
--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -306,6 +306,7 @@ function pluginFn(grunt: IGrunt) {
                 var referenceFile;
                 var referencePath;
                 if (!!reference) {
+                    reference = grunt.template.process(reference);
                     referenceFile = path.resolve(reference);
                     referencePath = path.dirname(referenceFile);
                 }


### PR DESCRIPTION
When using <%= parameter %> in reference config, it is not expanded to actual value. 
Should be fixed with this oneliner.
